### PR TITLE
Made Fix that if we have 0 message_on_delivery

### DIFF
--- a/src/queues/queue_data.rs
+++ b/src/queues/queue_data.rs
@@ -273,6 +273,9 @@ impl QueueData {
 
 fn update_delivery_time(subscriber: &mut QueueSubscriber, positive: bool) {
     let messages_on_delivery = subscriber.get_messages_amount_on_delivery();
+    if messages_on_delivery == 0 {
+        return;
+    }
 
     let delivery_duration =
         DateTimeAsMicroseconds::now().duration_since(subscriber.metrics.start_delivery_time);


### PR DESCRIPTION
0 messages-on-delivery


Metrics are not written